### PR TITLE
Handle environment hook failure

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -33,7 +33,9 @@ PROJECT_SLUG=$(urlencode "${PROJECT%.git}")
 
 TOKEN="${!GITLAB_TOKEN_ENV_VAR}"
 
-if [ "${BUILDKITE_COMMAND_EXIT_STATUS}" -eq 0 ]; then
+# BUILDKITE_COMMAND_EXIT_STATUS is not set in cases when the environment hook terminates with an error
+# Defaulting it to empty makes the comparison fail and the build gets marked correctly as failure
+if [ "${BUILDKITE_COMMAND_EXIT_STATUS:-}" -eq 0 ]; then
   status="success"
 else
   status="failed"

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -116,6 +116,21 @@ setup() {
   unstub curl
 }
 
+@test "Command exit code not set sets failure" {
+  unset BUILDKITE_COMMAND_EXIT_STATUS
+
+  stub curl \
+    "echo run curl against \${12}; while shift; do if [ \"\${1:-}\" = '--data-urlencode' ]; then echo with data \$2; fi; done"
+
+  run "$PWD"/hooks/pre-exit
+
+  assert_success
+  assert_output --partial "run curl against" # the stub
+  assert_output --partial "with data state=failed" # the stub
+
+  unstub curl
+}
+
 @test "JobID is passed through in URL if available" {
   export BUILDKITE_JOB_ID='my-step-id'
   stub curl \


### PR DESCRIPTION
If one of the hooks before the command hook is failing, then BUILDKITE_COMMAND_EXIT_STATUS is not set. Now that case is covered and the commit is being marked as failed.