### PR TITLE
Add $BUILDKITE_PARALLEL_JOB to $STATUS_NAME

### DIFF
--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -18,7 +18,7 @@ if [ -z "${!GITLAB_TOKEN_ENV_VAR:-}" ]; then
   exit 1
 fi
 
-STATUS_NAME=$(plugin_read_config CHECK_NAME "${BUILDKITE_STEP_KEY:-}")
+STATUS_NAME=$(plugin_read_config CHECK_NAME "${BUILDKITE_STEP_KEY:-}$([[ -n "$BUILDKITE_PARALLEL_JOB" ]] && echo "_${BUILDKITE_PARALLEL_JOB:-}")")
 
 if [ -z "${STATUS_NAME}" ]; then
   echo "+++ ERROR: if the step has no key, check-name must be provided"

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -193,3 +193,18 @@ setup() {
 
   unstub curl
 }
+
+@test "Check \$BUILDKITE_PARALLEL_JOB appended to \$STATUS_NAME" {
+  export BUILDKITE_PARALLEL_JOB=2
+
+  stub curl \
+    "echo run curl against \${12}; while shift; do if [ \"\${1:-}\" = '--data-urlencode' ]; then echo with data \$2; fi; done"
+
+  run "$PWD"/hooks/pre-exit
+
+  assert_success
+  assert_output --partial 'run curl' # the stub
+  assert_output --partial 'with data name=my-step_2' # the step name with parallel job number
+
+  unstub curl
+}


### PR DESCRIPTION
If we don't have this, the key is the same for each parallel step which causes the plugin to overwrite the same "check" on GitLab.

I initially tried using the `%n`/`%N` [index label helpers](https://buildkite.com/docs/tutorials/parallel-builds#parallel-jobs) in the `key:` in the `pipeline.yml` but it's only supported in the label.