### PR TITLE
Set status to "pending" in pre-checkout hook

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck source=lib/shared.bash
+. "$DIR/../lib/shared.bash"
+
+set_status "pending"


### PR DESCRIPTION
I'm not sure if there's a better [hook](https://buildkite.com/docs/agent/v3/hooks#job-lifecycle-hooks) to use. This should be sent as early as possible, ideally this would be sent before the agent picks up the build. I assume you'd need to introduce an explicit GitLab integration to support that though.