### PR TITLE
SUP-1248: Use process substitution to hide auth token

### DIFF
--- a/lib/curl.bash
+++ b/lib/curl.bash
@@ -28,11 +28,7 @@ set_status() {
     echo "Executing curl with ${CURL_ARGS[*]} + private token"
   fi
 
-  CURL_ARGS+=(
-    --header "Authorization: Bearer ${TOKEN}"
-  )
-
-  curl "${CURL_ARGS[@]}"
+  curl "${CURL_ARGS[@]}" --header @<(printf 'Authorization: Bearer %s\n' "${TOKEN}")
 }
 
 # Licensed under CC-BY-SA 4.0


### PR DESCRIPTION
Using process substitution allows using environment variables without exposing them through `ps`