### PR TITLE
Empty var fix, newline after curl

### DIFF
--- a/lib/curl.bash
+++ b/lib/curl.bash
@@ -29,6 +29,7 @@ set_status() {
   fi
 
   curl "${CURL_ARGS[@]}" --header @<(printf 'Authorization: Bearer %s\n' "${TOKEN}")
+  echo
 }
 
 # Licensed under CC-BY-SA 4.0

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -18,7 +18,7 @@ if [ -z "${!GITLAB_TOKEN_ENV_VAR:-}" ]; then
   exit 1
 fi
 
-STATUS_NAME=$(plugin_read_config CHECK_NAME "${BUILDKITE_STEP_KEY:-}$([[ -n "$BUILDKITE_PARALLEL_JOB" ]] && echo "_${BUILDKITE_PARALLEL_JOB:-}")")
+STATUS_NAME=$(plugin_read_config CHECK_NAME "${BUILDKITE_STEP_KEY:-}$([[ -n "${BUILDKITE_PARALLEL_JOB:-}" ]] && echo "_${BUILDKITE_PARALLEL_JOB:-}")")
 
 if [ -z "${STATUS_NAME}" ]; then
   echo "+++ ERROR: if the step has no key, check-name must be provided"


### PR DESCRIPTION
If `BUILDKITE_PARALLEL_JOB` was missing from a job, `STATUS_NAME` would not correctly evaluate. Adding a newline after the `curl` command prevents the log headings from the hooks that follow immediately after from being swallowed by this plugin's log headings.