### PR TITLE
Link to gitlab commit status docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) for setting th
 
 This plugin requires that the agent has a gitlab access token ([personal](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#personal-access-tokens), [group](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html), [project](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) or [OAuth2](https://docs.gitlab.com/ee/api/oauth2.html)) configured with `api` scope.
 
+Buildkite can now also set commit statuses directly from Buildkite for both GitLab.com and GitLab Self-Managed instances. [Check it out our docs](https://buildkite.com/docs/pipelines/source-control/gitlab#commit-statuses).
+
 ## Example
 
 The following pipeline just set the status to success

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) for setting th
 
 This plugin requires that the agent has a gitlab access token ([personal](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#personal-access-tokens), [group](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html), [project](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) or [OAuth2](https://docs.gitlab.com/ee/api/oauth2.html)) configured with `api` scope.
 
-Buildkite can now also set commit statuses directly from Buildkite for both GitLab.com and GitLab Self-Managed instances. [Check it out our docs](https://buildkite.com/docs/pipelines/source-control/gitlab#commit-statuses).
+Buildkite can now also set commit statuses directly from Buildkite for both GitLab.com and GitLab Self-Managed instances. [Check it out in our docs](https://buildkite.com/docs/pipelines/source-control/gitlab#commit-statuses).
 
 ## Example
 
@@ -22,7 +22,7 @@ steps:
 
 ### Required
 
-Technically, there are no required options for this plugin to work. It is to note that defaults will cause failures in the following situations:
+Technically, there are no required options for this plugin to work. It is worth noting that defaults will cause failures in the following situations:
 
 * `check-name`: if the step does not have a `key`
 * `token-var-name`: if the access token is not available in the variable `GITLAB_ACCESS_TOKEN`


### PR DESCRIPTION
We support commit statuses for gitlab directly from buildkite, now. There are still situations where the plugin is preferable, for example is folks are sensitive to permissions. But we should provide breadcrumbs both ways.